### PR TITLE
Changed setConfig function (and satGeoManual and bistaticGeometry fun…

### DIFF
--- a/source/lib/common/bistatic/bistaticGeometry.m
+++ b/source/lib/common/bistatic/bistaticGeometry.m
@@ -1,7 +1,10 @@
 %% Mehmet Kurum
 % Feb 25, 2017 
 
-function bistaticGeometry( rd_m )
+function [rd_m, idn, isn, osp, osn, Tgs, Tgr, TgrI, AntRotZ_Rx, ...
+          AntRotY_Rx, AntRot_Rx, AntRotZ_Tx, ellipse_FP_Rx_m, ...
+          AllPoints_m, AngT2R_rf, AngS2R_rf, AngT2S_sf] = bistaticGeometry
+
 
 %% GET GLOBAL DIRECTORIES
 dir_config = SimulationFolders.getInstance.config;
@@ -10,16 +13,18 @@ dir_config = SimulationFolders.getInstance.config;
 %% GET GLOBAL PARAMETERS
 % Simulation Parameters
 Nfz = SimParams.getInstance.Nfz;
-
+% Transmitter Parameters
+r_Tx_m = TxParams.getInstance.r_Tx_m;
 % Dynamic Parameters
 th0_Tx_list_deg = DynParams.getInstance.th0_Tx_list_deg;
 th0_Tx_deg = th0_Tx_list_deg( ParamsManager.index_Th );   % Currrent theta ( Incidence Angle )
 th0_Tx_rad = degtorad(th0_Tx_deg) ;
+el0_Tx_list_deg = DynParams.getInstance.el0_Tx_list_deg;
+el0_Tx_deg = el0_Tx_list_deg( ParamsManager.index_Th );
 ph0_Tx_list_deg = DynParams.getInstance.ph0_Tx_list_deg;
 ph0_Tx_deg = ph0_Tx_list_deg( ParamsManager.index_Ph );   % Current phi (Azimuth Angle (standard spherical coords) of transmitter's position)
 ph0_Tx_deg = 90 - ph0_Tx_deg ;                            % If it was the incoming signal's azimuth, we would add 180 degrees
 ph0_Tx_rad = degtorad(ph0_Tx_deg) ;
-
 % Receiver Parameters
 hr_m = RxParams.getInstance.hr_m;                   % Receiver altitude
 ant_pat_Rx_id = RxParams.getInstance.ant_pat_Rx_id; % Receiver antenna pattern generation method (Look at Constants.Rx_ant_pats)
@@ -83,6 +88,8 @@ AntRotZ_Tx = [ cos(ph0_Tx_rad), -sin(ph0_Tx_rad), 0 ;
 
 
 % Transmitter position
+% Slant range (Approximated)
+rd_m = sqrt( r_Tx_m ^ 2 - (Constants.re * cos( deg2rad( el0_Tx_deg ) )) ^ 2) - Constants.re * sin( deg2rad( el0_Tx_deg ) ) ;
 % T : Transmitter Antenna position
 pos_Tx_m = rd_m * [sin(th0_Tx_rad) * cos(ph0_Tx_rad); sin(th0_Tx_rad) * sin(ph0_Tx_rad); cos(th0_Tx_rad)] ;
 ht_m = pos_Tx_m(3) ;
@@ -263,77 +270,11 @@ AngT2S_sf = [th0; convertAngleTo360Range( ph0 ) ]  ;
 
 
 %% SAVE ALL
-% idn -  propagation vector (i_d^-)
-filename = 'idn' ;
-writeVar(dir_config, filename, idn) ;
-
-% isn - propagation vector (i_s^-)
-filename = 'isn' ;
-writeVar(dir_config, filename, isn) ;
-
-% osp - propagation vector (o_s^+)
-filename = 'osp' ;
-writeVar(dir_config, filename, osp) ;
-
-% osn - propagation vector (o_s^-)
-filename = 'osn' ;
-writeVar(dir_config, filename, osn) ;
-
-% Tgs - Transformation G -> S
-filename = 'Tgs' ;
-writeVar(dir_config, filename, Tgs) ;
-
-% Tgr - Transformation G -> R
-filename = 'Tgr' ;
-writeVar(dir_config, filename, Tgr) ;
-
-% TgrI - Transformation G -> RI
-filename = 'TgrI' ;
-writeVar(dir_config, filename, TgrI) ;
-
-% AntRotZ_Rx - Receiver Rotation about z-axis (Azimuth rotation)
-filename = 'AntRotZ_Rx' ;
-writeVar(dir_config, filename, AntRotZ_Rx) ;
-
-% AntRotY_Rx - Receiver Rotation about y-axis (Elevation rotation)
-filename = 'AntRotY_Rx' ;
-writeVar(dir_config, filename, AntRotY_Rx) ;
-
-% AntRot_Rx  - Receiver Rotation in both azimuth and elevation
-filename = 'AntRot_Rx' ;
-writeVar(dir_config, filename, AntRot_Rx) ;
-
-% AntRotZ_Tx -  Rotation matrix that describes azimuth direction of transmitted signal.
-filename = 'AntRotZ_Tx' ;
-writeVar(dir_config, filename, AntRotZ_Tx) ;
-
 % ellipses_FZ_m - specular point Fresnel zone [major and minor axes]
 filename = 'ellipses_FZ_m' ;
 writeVar(dir_config, filename, ellipses_FZ_m) ;
 
 filename = 'ellipse_centers_FZ_m' ;
 writeVar(dir_config, filename, ellipse_centers_FZ_m) ;
-
-% ellipse_FP_Rx_m - receiver footprint ellipse [major and minor axes]
-filename = 'ellipse_FP_Rx_m' ;
-writeVar(dir_config, filename, ellipse_FP_Rx_m) ;
-
-% AllPoints_m - pos_Tx_m, pos_SP_m, pos_Rx_m, pos_Gnd_m, pos_B_Rx_m, pos_FP_Rx_m, pos_FZ_m in ground (refrence) frame (G)
-filename = 'AllPoints_m' ;
-writeVar(dir_config, filename, AllPoints_m) ;
-
-% AngT2R_rf - Incidence angle (T -> R) in receiver frame (R)
-filename = 'AngT2R_rf' ;
-writeVar(dir_config, filename, AngT2R_rf) ;
-
-% AngS2R_rf - Incidence angle (S -> R) in receiver frame (R)
-filename = 'AngS2R_rf' ;
-writeVar(dir_config, filename, AngS2R_rf) ;
-
-% AngT2S_sf - Incidence angle (T -> S) in specular frame (S)
-filename = 'AngT2S_sf' ;
-writeVar(dir_config, filename, AngT2S_sf) ;
-
-
     
 end

--- a/source/lib/common/bistatic/calcFresnelZones.m
+++ b/source/lib/common/bistatic/calcFresnelZones.m
@@ -23,10 +23,7 @@ lambda_m = Constants.c / f_Hz ;     % Wavelength
 % TxParams.getInstance.el0_Tx_deg = 36.3287 ;        % Elevation angle
 th0_Tx_rad = degtorad(th0_Tx_deg) ;
 
-% Transmitter Height with respect to local planar ground plane
-% ht_m = rd * cos(th0_Tx_rad) ;
 % Transmitter/Reciever ground range
-% Dist_m = rd * sin(th0_Tx_rad) ;
 Dist_m = ht_m * tan(th0_Tx_rad) ;
 
 % Distance of specular point away from the receiver ground projection.

--- a/source/lib/common/bistatic/calcRotationMatrices.m
+++ b/source/lib/common/bistatic/calcRotationMatrices.m
@@ -18,39 +18,17 @@ pol_Rx = RxParams.getInstance.pol_Rx;
 ant_pat_struct_Rx = RxParams.getInstance.ant_pat_struct_Rx;
 % Ground Parameters
 polG = GndParams.getInstance.polG;
-
-
-%% READ AND LOAD META-DATA
-% Propagation Vectors
-% idn -  propagation vector (i_d^-)
-% isn - propagation vector (i_s^-)
-% isp - propagation vector (i_s^+)
-% osp - propagation vector (o_s^+)
-% osn - propagation vector (o_s^-)
-filenamex = 'idn' ;
-idn = readVar(dir_config, filenamex) ;
-filenamex = 'isn' ;
-isn = readVar(dir_config, filenamex) ;
-filenamex = 'osp' ;
-osp = readVar(dir_config, filenamex) ;
-isp = osp ;
-
+% Bistatic Parameters
+idn = BistaticParams.getInstance.idn;  % propagation vector (i_d^-)
+isn = BistaticParams.getInstance.isn;  % propagation vector (i_s^-)
+osp = BistaticParams.getInstance.osp;  % propagation vector (o_s^+)
+isp = osp;                             % propagation vector (i_s^+)
 % Transformations
-filenamex = 'Tgs' ;
-Tgs = readVar(dir_config, filenamex) ;
-filenamex = 'Tgr' ;
-Tgr = readVar(dir_config, filenamex) ;
-filenamex = 'TgrI' ;
-TgrI = readVar(dir_config, filenamex) ;
-filenamex = 'Tgt' ;
-Tgt = readVar(dir_config, filenamex) ;
-filenamex = 'TgtI' ;
-TgtI = readVar(dir_config, filenamex) ;
-
-
-% Polarization Definitions
-% antenna polarizations = Y, X, R, L
-% ground polarizations = H (phi), V (theta)
+Tgs = BistaticParams.getInstance.Tgs;
+Tgr = BistaticParams.getInstance.Tgr;
+TgrI = BistaticParams.getInstance.TgrI;
+Tgt = BistaticParams.getInstance.Tgt;
+TgtI = BistaticParams.getInstance.TgtI;
 
 
 %% CALCULATIONS

--- a/source/lib/common/bistatic/satGeometry.m
+++ b/source/lib/common/bistatic/satGeometry.m
@@ -2,7 +2,7 @@
 % Feb 25, 2017
 
 
-function [rd, PH0_deg, EL0_deg] ...
+function [rd, PH0_deg, EL0_deg, Tgt, TgtI] ...
     = satGeometry( LatSd, LonSd, LatBd, LonBd, LatGd, LonGd)
 
 %% GET GLOBAL DIRECTORIES

--- a/source/lib/common/bistatic/satGeometryManuel.m
+++ b/source/lib/common/bistatic/satGeometryManuel.m
@@ -2,7 +2,7 @@
 % April 6, 2017
 
 
-function satGeometryManuel(rd_m)
+function [Tgt, TgtI] = satGeometryManuel
 
 %%GET GLOBAL DIRECTORIES
 dir_config = SimulationFolders.getInstance.config;
@@ -72,20 +72,5 @@ Tgt = [uxt ; uyt ; uzt] ; % G -> T
 % Transformation matrix for transforming a vector from the ground frame
 % to Image transmitter system
 TgtI = [uxtI ; uytI ; uztI] ; % G -> TI
-
-
-%% SAVE ALL
-% Tgt - Transformation G -> T
-filename = 'Tgt' ;
-writeVar(dir_config, filename, Tgt) ;
-
-% TgtI - Transformation G -> TI
-filename = 'TgtI' ;
-writeVar(dir_config, filename, TgtI) ;
-
-% rd_m : slant range - distance between ground and Transmitter
-filename = 'rd_m' ;
-writeVar(dir_config, filename, rd_m) ;
-
 
 end

--- a/source/lib/common/bistatic/setConfig.m
+++ b/source/lib/common/bistatic/setConfig.m
@@ -5,22 +5,20 @@
 
 function setConfig
 
-%% GET GLOBAL PARAMETERS
-% Transmitter Parameters
-r_Tx_m = TxParams.getInstance.r_Tx_m;
-% Dynamic Parameters
-el0_Tx_list_deg = DynParams.getInstance.el0_Tx_list_deg;
-el0_Tx_deg = el0_Tx_list_deg( ParamsManager.index_Th );
-
-% Transmitter Geometry
-rd_m = sqrt( r_Tx_m ^ 2 - (Constants.re * cos( deg2rad( el0_Tx_deg ) )) ^ 2) - Constants.re * sin( deg2rad( el0_Tx_deg ) ) ; % ~ Slant range
 
 %% TO-DO: Work on the realistic SatGeo
 %% TRANSMITTER GEOMETRY
-satGeometryManuel(rd_m) ;
+[Tgt, TgtI] = satGeometryManuel();
+
 
 %% BISTATIC GEOMETRY
-bistaticGeometry( rd_m ) ;
+[rd_m, idn, isn, osp, osn, Tgs, Tgr, TgrI, AntRotZ_Rx, AntRotY_Rx, ...
+    AntRot_Rx, AntRotZ_Tx, ellipse_FP_Rx_m, AllPoints_m, AngT2R_rf, ...
+    AngS2R_rf, AngT2S_sf] = bistaticGeometry();
 
+
+BistaticParams.getInstance.initialize(rd_m, idn, isn, osp, osn, Tgt, ...
+    TgtI, Tgs, Tgr, TgrI, AntRotZ_Rx, AntRotY_Rx, AntRot_Rx, AntRotZ_Tx, ...
+    ellipse_FP_Rx_m, AllPoints_m, AngT2R_rf, AngS2R_rf, AngT2S_sf);
 
 end

--- a/source/lib/common/param/BistaticParams.m
+++ b/source/lib/common/param/BistaticParams.m
@@ -1,0 +1,208 @@
+classdef BistaticParams < handle
+    %% BISTATICPARAMS CLASS - Maintains bistatic parameters
+    % It keeps the parameters that are specific to the bistatic geometry in
+    % the configuration of each simulation. It can have only one 
+    % instance throughout the whole simulation thanks to Singleton Pattern. 
+    % Its properties should be initialized once in the simulation and then 
+    % used by other entities by using the get() functions provided by it.
+    
+    properties (SetAccess = private, GetAccess = public)
+        
+        % Slant range - distance between ground and Transmitter (meters)
+        rd_m 
+        
+        % Transformation matrix for transforming a vector from the ground 
+        % frame to transmitter system
+        Tgt
+        
+        % Transformation matrix for transforming a vector from the ground 
+        % frame to Image transmitter system
+        TgtI
+        
+        % propagation vector (i_d^-)
+        idn
+        
+        % propagation vector (i_s^-)
+        isn
+        
+        % propagation vector (o_s^+)
+        osp
+        
+        % propagation vector (o_s^-)
+        osn
+        
+        % Transformation Gnd -> Specular
+        Tgs
+        
+        % Transformation Gnd -> Rx
+        Tgr
+        
+        % Transformation Gnd -> Rx Image
+        TgrI
+        
+        % Receiver Rotation about z-axis (Azimuth rotation)
+        AntRotZ_Rx
+        
+        % Receiver Rotation about y-axis (Elevation rotation)
+        AntRotY_Rx
+        
+        % Receiver Rotation in both azimuth and elevation
+        AntRot_Rx
+        
+        % Transmitter Rotation about z-axis (Azimuth rotation)
+        AntRotZ_Tx
+        
+        % Receiver footprint ellipse [major and minor axes]
+        ellipse_FP_Rx_m
+        
+        % pos_Tx_m, pos_SP_m, pos_Rx_m, pos_Gnd_m, pos_B_Rx_m, 
+        % pos_FP_Rx_m, pos_FZ_m in ground (refrence) frame (G)
+        AllPoints_m
+        
+        % Incidence angle (T -> R) in receiver frame (R)
+        AngT2R_rf
+        
+        % Incidence angle (S -> R) in receiver frame (R)
+        AngS2R_rf
+        
+        % Incidence angle (T -> S) in specular frame (S)
+        AngT2S_sf
+        
+    end
+    
+    
+    methods (Access = private)
+    
+        function obj = BistaticParams
+            % BISTATICPARAMS - Private constructor
+        end
+    
+    end
+    
+    
+    methods (Static)
+        
+        function singleObj = getInstance
+            % GETINSTANCE - One instance for Singleton Pattern
+             persistent localObj
+             
+             if isempty(localObj) || ~isvalid(localObj)
+                localObj = BistaticParams;
+             end
+             
+             singleObj = localObj;
+        end
+        
+    end
+    
+    
+    methods
+        
+        function initialize(obj, rd_m, idn, isn, osp, osn, Tgt, TgtI, ...
+                Tgs, Tgr, TgrI, AntRotZ_Rx, AntRotY_Rx, AntRot_Rx, ...
+                AntRotZ_Tx, ellipse_FP_Rx_m, AllPoints_m, AngT2R_rf, ...
+                AngS2R_rf, AngT2S_sf )
+            % INITIALIZE - Initializes all the properties
+            
+            obj.rd_m = rd_m;
+            obj.idn = idn;
+            obj.isn = isn;
+            obj.osp = osp;
+            obj.osn = osn; 
+            obj.Tgt = Tgt;
+            obj.TgtI = TgtI;
+            obj.Tgs = Tgs;
+            obj.Tgr = Tgr;
+            obj.TgrI = TgrI;
+            obj.AntRotZ_Rx = AntRotZ_Rx;
+            obj.AntRotY_Rx = AntRotY_Rx;
+            obj.AntRot_Rx = AntRot_Rx;
+            obj.AntRotZ_Tx = AntRotZ_Tx;
+            obj.ellipse_FP_Rx_m = ellipse_FP_Rx_m;
+            obj.AllPoints_m = AllPoints_m;
+            obj.AngT2R_rf = AngT2R_rf;
+            obj.AngS2R_rf = AngS2R_rf;
+            obj.AngT2S_sf = AngT2S_sf;
+            
+        end
+        
+        function out = get.rd_m(obj)
+            out = obj.rd_m;        
+        end 
+        
+        function out = get.idn(obj)
+            out = obj.idn;        
+        end 
+        
+        function out = get.isn(obj)
+            out = obj.isn;        
+        end 
+        
+        function out = get.osp(obj)
+            out = obj.osp;        
+        end 
+        
+        function out = get.osn(obj)
+            out = obj.osn;        
+        end 
+        
+        function out = get.Tgt(obj)
+            out = obj.Tgt;        
+        end 
+        
+        function out = get.TgtI(obj)
+            out = obj.TgtI;        
+        end 
+        
+        function out = get.Tgr(obj)
+            out = obj.Tgr;        
+        end 
+        
+        function out = get.TgrI(obj)
+            out = obj.TgrI;        
+        end 
+        
+        function out = get.Tgs(obj)
+            out = obj.Tgs;        
+        end 
+        
+        function out = get.AntRotZ_Rx(obj)
+            out = obj.AntRotZ_Rx;        
+        end 
+        
+        function out = get.AntRotY_Rx(obj)
+            out = obj.AntRotY_Rx;        
+        end 
+        
+        function out = get.AntRot_Rx(obj)
+            out = obj.AntRot_Rx;        
+        end 
+        
+        function out = get.AntRotZ_Tx(obj)
+            out = obj.AntRotZ_Tx;        
+        end 
+        
+        function out = get.ellipse_FP_Rx_m(obj)
+            out = obj.ellipse_FP_Rx_m;        
+        end 
+        
+        function out = get.AllPoints_m(obj)
+            out = obj.AllPoints_m;        
+        end 
+        
+        function out = get.AngT2R_rf(obj)
+            out = obj.AngT2R_rf;        
+        end 
+        
+        function out = get.AngS2R_rf(obj)
+            out = obj.AngS2R_rf;        
+        end 
+        
+        function out = get.AngT2S_sf(obj)
+            out = obj.AngT2S_sf;        
+        end 
+        
+    end
+    
+end
+

--- a/source/lib/common/products/directTerm.m
+++ b/source/lib/common/products/directTerm.m
@@ -25,22 +25,19 @@ pol_Rx = RxParams.getInstance.pol_Rx;
 G0r_dB = RxParams.getInstance.G0r_dB;
 G0r = convertDecibelToNatural( G0r_dB );
 ant_pat_struct_Rx = RxParams.getInstance.ant_pat_struct_Rx;
+% Bistatic Parameters
+AllPoints_m = BistaticParams.getInstance.AllPoints_m;
+AngT2R_rf = BistaticParams.getInstance.AngT2R_rf;
 
 
 %% READ OR LOAD META-DATA
-% pos_FP_Rx_m: center of footprint, pos_FZ_m: center of fresnel zone
-% AllPoints_m = [pos_Tx_m, pos_TxI_m, pos_SP_m, pos_Rx_m, pos_RxI_m, pos_Gnd_m, pos_B_Rx_m, pos_FP_Rx_m, pos_FZ_m] ;
-filenamex = 'AllPoints_m' ;
-AllPoints_m = readVar( dir_config, filenamex );
-pos_Tx_m = AllPoints_m(:, 1) ;        % Transmitter
-pos_Rx_m = AllPoints_m(:, 4) ;         % Receiver
-
-filename = 'AngT2R_rf' ;
-AngT2R_rf = readVar( dir_config, filename) ;
-
 % Transmitter-Receiver Rotation Matrix
 load([dir_rot_lookup '\u_tr.mat'], 'u_tr')
 
+
+% AllPoints_m = [pos_Tx_m, pos_TxI_m, pos_SP_m, pos_Rx_m, pos_RxI_m, pos_Gnd_m, pos_B_Rx_m, pos_FP_Rx_m, pos_FZ_m] ;
+pos_Tx_m = AllPoints_m(:, 1) ;        % Transmitter
+pos_Rx_m = AllPoints_m(:, 4) ;         % Receiver
 
 % Receiver Antenna Pattern and Look-up Angles (th and ph)
 g = ant_pat_struct_Rx.g;

--- a/source/lib/common/products/specularTerm.m
+++ b/source/lib/common/products/specularTerm.m
@@ -29,24 +29,13 @@ g_t = TxParams.getInstance.g_t ; % ideal
 e_t1 = TxParams.getInstance.e_t1 ; 
 e_t2 = TxParams.getInstance.e_t2 ;
 pol_Tx = TxParams.getInstance.pol_Tx;
+% Bistatic Parameters
+AllPoints_m = BistaticParams.getInstance.AllPoints_m;
+AngS2R_rf = BistaticParams.getInstance.AngS2R_rf; % SP->Rx Rotation Angle
+AngT2S_sf = BistaticParams.getInstance.AngT2S_sf; % Tx->SP Rotation Angle
 
 
 %% READ OR LOAD META-DATA
-% Read All Positions
-% AllPoints_m = [pos_Tx_m, pos_TxI_m, pos_SP_m, pos_Rx_m, pos_RxI_m, pos_Gnd_m, pos_B_Rx_m, pos_FP_Rx_m, pos_FZ_m] ;
-filenamex = 'AllPoints_m' ;
-AllPoints_m = readVar(dir_config, filenamex) ;
-pos_Tx_m = AllPoints_m(:, 1) ;        % Transmitter position
-pos_SP_m = AllPoints_m(:, 3) ;       % Specular point
-pos_Rx_m = AllPoints_m(:, 4) ;        % Receiver position
-
-% Read SP-to-Rec Rotation Angle
-filename = 'AngS2R_rf' ;
-AngS2R_rf = readVar(dir_config, filename) ;
-% Read Sat-to-SP Rotation Angle
-filename = 'AngT2S_sf' ;
-AngT2S_sf = readVar(dir_config, filename) ;
-
 % Transmitter-Receiver Rotation Matrix
 load([dir_rot_lookup '\u_ts.mat'], 'u_ts')
 load([dir_rot_lookup '\u_sr.mat'], 'u_sr')
@@ -69,6 +58,11 @@ g_r0 = [1 0 ; 0 1] ; % ideal
 
 
 %% CALCULATIONS
+% AllPoints_m = [pos_Tx_m, pos_TxI_m, pos_SP_m, pos_Rx_m, pos_RxI_m, pos_Gnd_m, pos_B_Rx_m, pos_FP_Rx_m, pos_FZ_m] ;
+pos_Tx_m = AllPoints_m(:, 1) ;        % Transmitter position
+pos_SP_m = AllPoints_m(:, 3) ;       % Specular point
+pos_Rx_m = AllPoints_m(:, 4) ;        % Receiver position
+
 % Slant Range
 ST = pos_SP_m - pos_Tx_m ;         % Transmitter to Specular
 r_st = vectorMagnitude(ST) ;  % slant range

--- a/source/lib/scobi_ml/SCoBiML/SpecularReflection.m
+++ b/source/lib/scobi_ml/SCoBiML/SpecularReflection.m
@@ -26,6 +26,9 @@ e_t2 = TxParams.getInstance.e_t2 ;
 ant_pat_Rx_id = RxParams.getInstance.ant_pat_Rx_id;
 ant_pat_res_deg = RxParams.getInstance.ant_pat_res_deg;
 ant_pat_struct_Rx = RxParams.getInstance.ant_pat_struct_Rx;
+% Bistatic Parameters
+AngS2R_rf = BistaticParams.getInstance.AngS2R_rf; % SP->Rx Rotation Angle
+AngT2S_sf = BistaticParams.getInstance.AngT2S_sf; % Tx->SP Rotation Angle
 
 
 %% INITIALIZE REQUIRED PARAMETERS
@@ -37,14 +40,8 @@ g_r0 = [1 0 ; 0 1] ; % ideal
 %% Load Transmitter-Receiver Rotation Matrix
 load([dir_rot_lookup '\u_ts.mat'], 'u_ts')
 load([dir_rot_lookup '\u_sr.mat'], 'u_sr')
+ 
 
-% Read SP-to-Rec Rotation Angle
-filename = 'AngS2R_rf' ;
-AngS2R_rf = readVar(dir_config, filename) ;
-
-% Read Sat-to-SP Rotation Angle
-filename = 'AngT2S_sf' ;
-AngT2S_sf = readVar(dir_config, filename) ;
 
 % Read Incremental Propagation Constant
 filename = 'dKz' ;

--- a/source/lib/scobi_veg/analysis/MSU-20180406-plot_01-CORN_PAPER/plotStalkPos.m
+++ b/source/lib/scobi_veg/analysis/MSU-20180406-plot_01-CORN_PAPER/plotStalkPos.m
@@ -56,7 +56,11 @@ dir_config = SimulationFolders.getInstance.config;
 
 
 %% GET GLOBAL PARAMETERS
+% Simulation Parameters
 Nfz = SimParams.getInstance.Nfz;
+% Bistatic Parameters
+Tgs = BistaticParams.getInstance.Tgs;   % Transformation Gnd -> Specular
+AntRotZ_Tx = BistaticParams.getInstance.AntRotZ_Tx;   % Transmitter Rotation along Z-Axis
 
 
 %% READ META-DATA
@@ -69,12 +73,6 @@ fileName = 'ellipses_FZ_m' ;
 ellipses_FZ_m = readVar(dir_config, fileName) ;
 fileName = 'ellipse_centers_FZ_m' ;
 ellipse_centers_FZ_m = readVar(dir_config, fileName) ;
-% Transmitter Rotation along Z-Axis
-fileName = 'AntRotZ_Tx' ;
-AntRotZ_Tx = readVar(dir_config, fileName) ;
-% Ground to Specular Frame Transformation
-fileName = 'Tgs' ;
-Tgs = readVar(dir_config, fileName) ;
 
 
 %% FIGURE

--- a/source/lib/scobi_veg/monte_carlo/calcScatAngles.m
+++ b/source/lib/scobi_veg/monte_carlo/calcScatAngles.m
@@ -13,12 +13,17 @@ dir_observation = SimulationFolders.getInstance.observation ;
 dir_distance = SimulationFolders.getInstance.distance ;
 
 
-%% READ META-DATA (TRANSFORMATIONS AND CONFIGURATION)
-% All Positions
-% AllPoints_m = [pos_Tx_m, pos_TxI_m, pos_SP_m, pos_Rx_m, pos_RxI_m, pos_Gnd_m, pos_B_Rx_m, pos_FP_Rx_m, pos_FZ_m] ;
-filenamex = 'AllPoints_m' ;
-AllPoints_m = readVar(dir_config, filenamex) ;
+%% GET GLOBAL PARAMETERS
+% Bistatic Parameters
+isn = BistaticParams.getInstance.isn;   % propagation vector (i_s^-)
+osp = BistaticParams.getInstance.osp;   % propagation vector (i_s^+=o_s^+)
+Tgs = BistaticParams.getInstance.Tgs;   % Transformation Gnd -> Specular
+Tgr = BistaticParams.getInstance.Tgr;   % Transformation Gnd -> Rx
+TgrI = BistaticParams.getInstance.TgrI; % Transformation Gnd -> Rx Image
+AllPoints_m = BistaticParams.getInstance.AllPoints_m;
 
+
+% AllPoints_m = [pos_Tx_m, pos_TxI_m, pos_SP_m, pos_Rx_m, pos_RxI_m, pos_Gnd_m, pos_B_Rx_m, pos_FP_Rx_m, pos_FZ_m]
 pos_Tx_m = AllPoints_m(:, 1);        % Transmitter
 pos_TxI_m = AllPoints_m(:, 2);        % Transmitter Image
 
@@ -26,18 +31,7 @@ pos_Rx_m = AllPoints_m(:, 4);        % Receiver
 pos_RxI_m = AllPoints_m(:, 5);       % Receiver Image
 
 % Incident unit vectors (only in one direction - transmitter is far away)
-filenamex = 'isn' ;
-isn = readVar(dir_config, filenamex) ;   % propagation vector (i_s^-)
-filenamex = 'osp' ;
-isp = readVar(dir_config, filenamex) ;   % propagation vector (i_s^+=o_s^+)
-
-% Transformations
-filenamex = 'Tgs' ;
-Tgs = readVar(dir_config, filenamex) ;   % G -> S
-filenamex = 'Tgr' ;
-Tgr = readVar(dir_config, filenamex) ;   % G -> R
-filenamex = 'TgrI' ;
-TgrI = readVar(dir_config, filenamex) ;  % G -> RI
+isp = osp;
 
 
 %% CALCULATIONS

--- a/source/lib/scobi_veg/monte_carlo/generateHomScatPositions.m
+++ b/source/lib/scobi_veg/monte_carlo/generateHomScatPositions.m
@@ -11,12 +11,11 @@ scat_cal_veg = VegParams.getInstance.scat_cal_veg;
 TYPKND = VegParams.getInstance.TYPKND;
 dsty = VegParams.getInstance.dsty;
 dim3_m = VegParams.getInstance.dim3_m;
+% Bistatic Parameters
+AllPoints_m = BistaticParams.getInstance.AllPoints_m;
 
 
-%% READ META-DATA
-% All Positions
 % AllPoints_m = [pos_Tx_m, pos_TxI_m, pos_SP_m, pos_Rx_m, pos_RxI_m, pos_Gnd_m, pos_B_Rx_m, pos_FP_Rx_m, pos_FZ_m] ;
-AllPoints_m = readVar(dir_config, 'AllPoints_m') ;
 pos_Tx_m = AllPoints_m(:, 1) ;          % Transmitter position
 ht = pos_Tx_m(3) ;                    % Transmitter height
 
@@ -92,10 +91,8 @@ hr_m = RxParams.getInstance.hr_m ;     % Receiver height
 % Vegetation Parameters
 TYPES = VegParams.getInstance.TYPES;
 dim_layers_m = VegParams.getInstance.dim_layers_m;
-
-
-%% READ META-DATA
-Tgs = readVar( dir_config, 'Tgs' ) ;   % G -> SP
+% Bistatic Parameters
+Tgs = BistaticParams.getInstance.Tgs;   % Transformation Gnd -> Specular
 
 
 %% CALCULATIONS

--- a/source/lib/scobi_veg/products/diffuseTerm.m
+++ b/source/lib/scobi_veg/products/diffuseTerm.m
@@ -33,13 +33,11 @@ G0r = convertDecibelToNatural( G0r_dB );
 % Vegetation Parameters
 scat_cal_veg = VegParams.getInstance.scat_cal_veg ;
 TYPKND = VegParams.getInstance.TYPKND;
+% Bistatic Parameters
+AllPoints_m = BistaticParams.getInstance.AllPoints_m;
 
 
-%% READ OR LOAD META-DATA
-% Positions relative to ground
 % AllPoints_m = [pos_Tx_m, pos_TxI_m, pos_SP_m, pos_Rx_m, pos_RxI_m, pos_Gnd_m, pos_B_Rx_m, pos_FP_Rx_m, pos_FZ_m] ;
-filenamex = 'AllPoints_m' ;
-AllPoints_m = readVar(dir_config, filenamex) ;
 pos_Tx_m = AllPoints_m(:, 1) ; % - d_layer_m ;        % Transmitter with respect to veg top
 pos_SP_m = AllPoints_m(:, 3) ;       % Specular point  (at top of vegetation)
 pos_Rx_m = AllPoints_m(:, 4) ; % - d_layer_m ;        % Receiver with respect to veg top

--- a/source/lib/scobi_veg/products/diffuseTerm_B1.m
+++ b/source/lib/scobi_veg/products/diffuseTerm_B1.m
@@ -31,13 +31,11 @@ G0r = convertDecibelToNatural( G0r_dB );
 % Vegetation Parameters
 scat_cal_veg = VegParams.getInstance.scat_cal_veg ;
 TYPKND = VegParams.getInstance.TYPKND;
+% Bistatic Parameters
+AllPoints_m = BistaticParams.getInstance.AllPoints_m;
 
 
-%% READ OR LOAD META-DATA
-% Positions relative to ground
 % AllPoints_m = [pos_Tx_m, pos_TxI_m, pos_SP_m, pos_Rx_m, pos_RxI_m, pos_Gnd_m, pos_B_Rx_m, pos_FP_Rx_m, pos_FZ_m] ;
-filenamex = 'AllPoints_m' ;
-AllPoints_m = readVar(dir_config, filenamex) ;
 pos_Tx_m = AllPoints_m(:, 1) ; % - d_layer_m ;        % Transmitter with respect to veg top
 pos_SP_m = AllPoints_m(:, 3) ;       % Specular point  (at top of vegetation)
 pos_Rx_m = AllPoints_m(:, 4) ; % - d_layer_m ;        % Receiver with respect to veg top

--- a/source/lib/scobi_veg/products/diffuseTerm_B1_G1.m
+++ b/source/lib/scobi_veg/products/diffuseTerm_B1_G1.m
@@ -31,14 +31,11 @@ G0r = convertDecibelToNatural( G0r_dB );
 % Vegetation Parameters
 scat_cal_veg = VegParams.getInstance.scat_cal_veg ;
 TYPKND = VegParams.getInstance.TYPKND;
+% Bistatic Parameters
+AllPoints_m = BistaticParams.getInstance.AllPoints_m;
 
 
-%% READ OR LOAD META-DATA
-% Positions relative to ground
-% pos_FP_Rx_m: center of footprint, pos_FZ_m: center of fresnel zone
 % AllPoints_m = [pos_Tx_m, pos_TxI_m, pos_SP_m, pos_Rx_m, pos_RxI_m, pos_Gnd_m, pos_B_Rx_m, pos_FP_Rx_m, pos_FZ_m] ;
-filenamex = 'AllPoints_m' ;
-AllPoints_m = readVar(dir_config, filenamex) ;
 pos_Tx_m = AllPoints_m(:, 1) ; % - d_layer_m ;        % Transmitter with respect to veg top
 pos_SP_m = AllPoints_m(:, 3) ;       % Specular point  (at top of vegetation)
 pos_Rx_m = AllPoints_m(:, 4) ; % - d_layer_m ;        % Receiver with respect to veg top

--- a/source/lib/scobi_veg/products/diffuseTerm_G1.m
+++ b/source/lib/scobi_veg/products/diffuseTerm_G1.m
@@ -31,13 +31,11 @@ G0r = convertDecibelToNatural( G0r_dB );
 % Vegetation Parameters
 scat_cal_veg = VegParams.getInstance.scat_cal_veg ;
 TYPKND = VegParams.getInstance.TYPKND;
+% Bistatic Parameters
+AllPoints_m = BistaticParams.getInstance.AllPoints_m;
 
 
-%% READ OR LOAD META-DATA
-% Positions relative to ground
 % AllPoints_m = [pos_Tx_m, pos_TxI_m, pos_SP_m, pos_Rx_m, pos_RxI_m, pos_Gnd_m, pos_B_Rx_m, pos_FP_Rx_m, pos_FZ_m] ;
-filenamex = 'AllPoints_m' ;
-AllPoints_m = readVar(dir_config, filenamex) ;
 pos_Tx_m = AllPoints_m(:, 1) ; % - d_layer_m ;        % Transmitter with respect to veg top
 pos_SP_m = AllPoints_m(:, 3) ;       % Specular point  (at top of vegetation)
 pos_Rx_m = AllPoints_m(:, 4) ; % - d_layer_m ;        % Receiver with respect to veg top


### PR DESCRIPTION
…ctions in it) in the way that they no longer write bistatic parameters into disk; instead it puts those into BistaicParams class. The only two exceptions are "ellipses_FZ_m" and "ellipse_centers_FZ_m", which are writtne to disk in the function "bistaticGeometry". My reason for this is that these two parameters are commonly used by analysis functions (plot.... functions) after closing the simulation. I will first make sure if I can find a way for them, then I can move these two as well.